### PR TITLE
pod fix

### DIFF
--- a/lib/Farabi.pm
+++ b/lib/Farabi.pm
@@ -110,6 +110,8 @@ Please run the following command and then open http://127.0.0.1:4040 in your bro
 
 =head1 FEATURES
 
+=over
+
 =item Open File(s)
 
 The dialog provides partial filename search inside the directory where Farabi was started.
@@ -117,6 +119,8 @@ Matched single or multiple file selections can then be opened in one batch.
 
 B<WARNING:> Please do not start farabi in a folder with too many files like your home directory
 because this feature's performance will eventually suffer.
+
+=back
 
 =head1 TECHNOLOGIES USED
 


### PR DESCRIPTION
Should fix these errors:

Around line 121:
'=item' outside of any '=over'
Around line 129:
You forgot a '=back' before '=head1'

Currently seen at the bottom of this page:
https://metacpan.org/module/Farabi
